### PR TITLE
Socket Authentication Middleware

### DIFF
--- a/backend/src/lib/socket.js
+++ b/backend/src/lib/socket.js
@@ -1,6 +1,8 @@
 import { Server } from "socket.io";
 import http from "http";
 import express from "express";
+import jwt from "jsonwebtoken";
+import User from "../models/user.model.js";
 
 const app = express();
 const server = http.createServer(app);
@@ -25,9 +27,40 @@ export function getReciverSocketId(reciverId){
 // as soon as user login we will add him to this map
 const userSocketMap={};  // userId : socketId (key :value)
 
+// Socket authentication middleware
+io.use(async (socket, next) => {
+    try {
+        const token = socket.handshake.auth.token || socket.handshake.query.token;
+        
+        if (!token) {
+            return next(new Error("Authentication error: No token provided"));
+        }
+
+        const decoded = jwt.verify(token, process.env.JWT_SECRET);
+        
+        if (!decoded) {
+            return next(new Error("Authentication error: Invalid token"));
+        }
+
+        const user = await User.findById(decoded.userId).select("-password");
+        
+        if (!user) {
+            return next(new Error("Authentication error: User not found"));
+        }
+
+        // Attach user to socket for use in event handlers
+        socket.user = user;
+        next();
+    } catch (err) {
+        console.log("Socket authentication error:", err.message);
+        next(new Error("Authentication error: " + err.message));
+    }
+});
+
 io.on("connection",(socket)=>{
     console.log("a user connected",socket.id);
-    const userId=socket.handshake.query.userId;
+    // Use authenticated user from middleware
+    const userId = socket.user?._id || socket.handshake.query.userId;
     if(userId){
         userSocketMap[userId]=socket.id;
     }

--- a/frontend/src/store/useAuthStore.js
+++ b/frontend/src/store/useAuthStore.js
@@ -97,9 +97,15 @@ export const useAuthStore = create((set, get) => ({
         const {authUser}=get();
         if(!authUser||get().socket?.connected) return;
 
-        const socket=io(BASE_URL,{
-            query:{userId:authUser._id}
+        // Get the JWT token from cookies
+        const token = document.cookie
+            .split('; ')
+            .find(row => row.startsWith('jwt='))
+            ?.split('=')[1];
 
+        const socket=io(BASE_URL,{
+            query:{userId:authUser._id},
+            auth: { token }
         });
         socket.connect();
         set({socket:socket});


### PR DESCRIPTION
## Changes Made:
backend/src/lib/socket.js - Added JWT authentication middleware:

- Imported jsonwebtoken and User model
- Created socket authentication middleware using io.use() that:
- Extracts JWT token from socket.handshake.auth.token or socket.handshake.query.token
- Verifies the token using jwt.verify()
- Fetches the user from the database
- Attaches the verified user to socket.user
- Rejects unauthenticated connections with appropriate error messages
- Updated the connection handler to use socket.user?._id from the authenticated middleware

frontend/src/store/useAuthStore.js - Updated socket connection to include auth token:

- Added code to extract JWT token from cookies
- Modified connectSocket() to pass the token via auth: { token } option in the socket connection

solves #5