### PR TITLE
fix: Console.log Statements Left in Production Code

### DIFF
--- a/backend/node_modules/.package-lock.json
+++ b/backend/node_modules/.package-lock.json
@@ -4,6 +4,26 @@
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "node_modules/@hapi/address": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
@@ -61,6 +81,16 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -90,6 +120,12 @@
       "dependencies": {
         "undici-types": "~7.14.0"
       }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
@@ -132,6 +168,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -317,6 +359,52 @@
         "node": ">=9"
       }
     },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -486,6 +574,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -703,6 +797,12 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -732,6 +832,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/form-data": {
       "version": "2.5.5",
@@ -1030,11 +1136,41 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
+    },
+    "node_modules/joi": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
+      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
@@ -1088,6 +1224,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -1135,6 +1277,23 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1434,6 +1593,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1645,6 +1813,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1953,6 +2130,15 @@
         "memory-pager": "^1.0.2"
       }
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2021,6 +2207,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2063,6 +2255,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/type-is": {
@@ -2136,6 +2337,70 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/wrappy": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,10 +19,31 @@
         "mongoose": "^8.19.1",
         "nodemailer": "^8.0.1",
         "sib-api-v3-sdk": "^8.5.0",
-        "socket.io": "^4.8.1"
+        "socket.io": "^4.8.1",
+        "winston": "^3.19.0"
       },
       "devDependencies": {
         "nodemon": "^3.1.14"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@hapi/address": {
@@ -82,6 +103,16 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -111,6 +142,12 @@
       "dependencies": {
         "undici-types": "~7.14.0"
       }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
@@ -153,6 +190,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -338,6 +381,52 @@
         "node": ">=9"
       }
     },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -507,6 +596,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -724,6 +819,12 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -753,6 +854,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/form-data": {
       "version": "2.5.5",
@@ -1066,11 +1173,41 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
+    },
+    "node_modules/joi": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
+      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
@@ -1124,6 +1261,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -1171,6 +1314,23 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1470,6 +1630,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1681,6 +1850,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1989,6 +2167,15 @@
         "memory-pager": "^1.0.2"
       }
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2057,6 +2244,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2099,6 +2292,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/type-is": {
@@ -2172,6 +2374,70 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/wrappy": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,8 @@
     "mongoose": "^8.19.1",
     "nodemailer": "^8.0.1",
     "sib-api-v3-sdk": "^8.5.0",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "winston": "^3.19.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.14"

--- a/backend/src/controllers/auth.controller.js
+++ b/backend/src/controllers/auth.controller.js
@@ -3,6 +3,7 @@ import User from "../models/user.model.js";
 import bcrypt from "bcryptjs";
 import cloudinary from "../lib/cloudinary.js";
 import { sendEmail } from "../lib/email.js";
+import logger from "../lib/logger.js";
 
 const normalizeEmail = (email = "") => email.trim().toLowerCase();
 const normalizeUsername = (username = "") => username.trim().toLowerCase();
@@ -91,7 +92,11 @@ export const signup = async (req, res) => {
     const token = generateToken(newUser._id, res);
     return res.status(201).json(buildAuthUserResponse(newUser, "User created successfully", token));
   } catch (err) {
-    console.log("error in signup controller", err);
+    logger.error("Signup controller failed", {
+      context: "auth.signup",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal server error" });
   }
 };
@@ -130,7 +135,11 @@ export const login = async (req, res) => {
 
     return res.status(200).json(buildAuthUserResponse(user, "Login successful", token));
   } catch (err) {
-    console.log("error in login controller", err);
+    logger.error("Login controller failed", {
+      context: "auth.login",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal server error" });
   }
 };
@@ -145,7 +154,11 @@ export const logout = async (req, res) => {
     });
     return res.status(200).json({ message: "Logout successful" });
   } catch (err) {
-    console.log("error in logout controller", err);
+    logger.error("Logout controller failed", {
+      context: "auth.logout",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal server error" });
   }
 };
@@ -167,7 +180,11 @@ export const updateProfile = async (req, res) => {
 
     return res.status(200).json(updatedUser);
   } catch (err) {
-    console.log("error in update profile controller", err);
+    logger.error("Update profile controller failed", {
+      context: "auth.updateProfile",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal server error" });
   }
 };
@@ -177,7 +194,11 @@ export const checkAuth = async (req, res) => {
     const token = generateToken(req.user._id, res);
     return res.status(200).json(buildAuthUserResponse(req.user, null, token));
   } catch (err) {
-    console.log("error in check auth controller", err);
+    logger.error("Check auth controller failed", {
+      context: "auth.checkAuth",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal server error" });
   }
 };
@@ -208,13 +229,25 @@ export const forgotPassword = async (req, res) => {
 
     try {
       const emailResponse = await sendEmail(mailOption);
-      console.log("Email sent successfully:", emailResponse);
+      logger.info("Forgot password OTP email sent", {
+        context: "auth.forgotPassword",
+        messageId: emailResponse?.messageId,
+      });
       return res.status(200).json({ message: "OTP sent to email" });
     } catch (err) {
-      console.error("otp mailed failed", err.message);
+      logger.error("Failed to send forgot password OTP email", {
+        context: "auth.forgotPassword",
+        error: err.message,
+        stack: err.stack,
+      });
       return res.status(500).json({ message: "Failed to send OTP email" });
     }
   } catch (error) {
+    logger.error("Forgot password controller failed", {
+      context: "auth.forgotPassword",
+      error: error.message,
+      stack: error.stack,
+    });
     return res.status(500).json({ message: "Internal server error" });
   }
 };
@@ -248,7 +281,11 @@ export const resetPassword = async (req, res) => {
 
     return res.status(200).json({ message: "Password reset successfully" });
   } catch (error) {
-    console.log("error in reset password controller", error);
+    logger.error("Reset password controller failed", {
+      context: "auth.resetPassword",
+      error: error.message,
+      stack: error.stack,
+    });
     return res.status(500).json({ message: "Internal server error" });
   }
 };

--- a/backend/src/controllers/group.controller.js
+++ b/backend/src/controllers/group.controller.js
@@ -3,6 +3,7 @@ import Message from "../models/message.model.js";
 import User from "../models/user.model.js";
 import { uploadImage, uploadPdf, uploadAudio, uploadAvatar } from "../lib/cloudinaryUpload.js";
 import { io } from "../lib/socket.js";
+import logger from "../lib/logger.js";
 
 // Create a new group
 export const createGroup = async (req, res) => {
@@ -31,7 +32,11 @@ export const createGroup = async (req, res) => {
 
         res.status(201).json(newGroup);
     } catch (err) {
-        console.error("Error creating group:", err);
+        logger.error("Create group failed", {
+            context: "group.createGroup",
+            error: err.message,
+            stack: err.stack,
+        });
         res.status(500).json({ message: "Internal Server Error" });
     }
 };
@@ -48,7 +53,11 @@ export const getMyGroups = async (req, res) => {
 
         res.status(200).json(groups);
     } catch (err) {
-        console.error("Error fetching groups:", err);
+        logger.error("Fetch groups failed", {
+            context: "group.getMyGroups",
+            error: err.message,
+            stack: err.stack,
+        });
         res.status(500).json({ message: "Internal Server Error" });
     }
 };
@@ -74,7 +83,11 @@ export const getGroupById = async (req, res) => {
 
         res.status(200).json(group);
     } catch (err) {
-        console.error("Error fetching group:", err);
+        logger.error("Fetch group by id failed", {
+            context: "group.getGroupById",
+            error: err.message,
+            stack: err.stack,
+        });
         res.status(500).json({ message: "Internal Server Error" });
     }
 };
@@ -120,7 +133,11 @@ export const updateGroup = async (req, res) => {
 
         res.status(200).json(group);
     } catch (err) {
-        console.error("Error updating group:", err);
+        logger.error("Update group failed", {
+            context: "group.updateGroup",
+            error: err.message,
+            stack: err.stack,
+        });
         res.status(500).json({ message: "Internal Server Error" });
     }
 };
@@ -167,7 +184,11 @@ export const addMember = async (req, res) => {
 
         res.status(200).json(group);
     } catch (err) {
-        console.error("Error adding member:", err);
+        logger.error("Add group member failed", {
+            context: "group.addMember",
+            error: err.message,
+            stack: err.stack,
+        });
         res.status(500).json({ message: "Internal Server Error" });
     }
 };
@@ -212,7 +233,11 @@ export const removeMember = async (req, res) => {
 
         res.status(200).json(group);
     } catch (err) {
-        console.error("Error removing member:", err);
+        logger.error("Remove group member failed", {
+            context: "group.removeMember",
+            error: err.message,
+            stack: err.stack,
+        });
         res.status(500).json({ message: "Internal Server Error" });
     }
 };
@@ -253,7 +278,11 @@ export const leaveGroup = async (req, res) => {
 
         res.status(200).json({ message: "Left group successfully" });
     } catch (err) {
-        console.error("Error leaving group:", err);
+        logger.error("Leave group failed", {
+            context: "group.leaveGroup",
+            error: err.message,
+            stack: err.stack,
+        });
         res.status(500).json({ message: "Internal Server Error" });
     }
 };
@@ -292,7 +321,11 @@ export const deleteGroup = async (req, res) => {
 
         res.status(200).json({ message: "Group deleted successfully" });
     } catch (err) {
-        console.error("Error deleting group:", err);
+        logger.error("Delete group failed", {
+            context: "group.deleteGroup",
+            error: err.message,
+            stack: err.stack,
+        });
         res.status(500).json({ message: "Internal Server Error" });
     }
 };
@@ -356,7 +389,11 @@ export const sendGroupMessage = async (req, res) => {
 
         res.status(201).json(newMessage);
     } catch (err) {
-        console.error("Error sending group message:", err);
+        logger.error("Send group message failed", {
+            context: "group.sendGroupMessage",
+            error: err.message,
+            stack: err.stack,
+        });
         res.status(500).json({ message: "Internal Server Error" });
     }
 };
@@ -385,7 +422,11 @@ export const getGroupMessages = async (req, res) => {
 
         res.status(200).json(messages);
     } catch (err) {
-        console.error("Error fetching group messages:", err);
+        logger.error("Fetch group messages failed", {
+            context: "group.getGroupMessages",
+            error: err.message,
+            stack: err.stack,
+        });
         res.status(500).json({ message: "Internal Server Error" });
     }
 };
@@ -416,7 +457,11 @@ export const getAvailableUsers = async (req, res) => {
 
         res.status(200).json(availableUsers);
     } catch (err) {
-        console.error("Error fetching available users:", err);
+        logger.error("Fetch available users failed", {
+            context: "group.getAvailableUsers",
+            error: err.message,
+            stack: err.stack,
+        });
         res.status(500).json({ message: "Internal Server Error" });
     }
 };

--- a/backend/src/controllers/message.controller.js
+++ b/backend/src/controllers/message.controller.js
@@ -5,6 +5,7 @@ import { getReciverSocketId, io } from "../lib/socket.js";
 import Conversation from "../models/conversation.model.js";
 import Message from "../models/message.model.js";
 import User from "../models/user.model.js";
+import logger from "../lib/logger.js";
 
 const escapeRegex = (value = "") => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
@@ -173,7 +174,11 @@ export const getUsersForSidebar = async (req, res) => {
 
     return res.status(200).json({ filterUsers });
   } catch (err) {
-    console.error("Error fetching users for sidebar:", err);
+    logger.error("Fetch sidebar users failed", {
+      context: "message.getUsersForSidebar",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };
@@ -212,7 +217,11 @@ export const getMessage = async (req, res) => {
 
     return res.status(200).json(messages);
   } catch (err) {
-    console.error("Error fetching messages:", err);
+    logger.error("Fetch messages failed", {
+      context: "message.getMessage",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };
@@ -303,7 +312,11 @@ export const sendMessage = async (req, res) => {
 
     return res.status(201).json(populatedMessage);
   } catch (err) {
-    console.error("Error sending message:", err);
+    logger.error("Send message failed", {
+      context: "message.sendMessage",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };
@@ -332,7 +345,11 @@ export const markMessageAsRead = async (req, res) => {
       count: updatedMessages.modifiedCount,
     });
   } catch (err) {
-    console.error("Error marking messages as read:", err);
+    logger.error("Mark messages as read failed", {
+      context: "message.markMessageAsRead",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };
@@ -358,7 +375,11 @@ export const searchMessages = async (req, res) => {
 
     return res.status(200).json(messages);
   } catch (err) {
-    console.error("Error searching messages:", err);
+    logger.error("Search messages failed", {
+      context: "message.searchMessages",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };
@@ -377,7 +398,11 @@ export const getAllMessages = async (req, res) => {
 
     return res.status(200).json(messages);
   } catch (err) {
-    console.error("Error exporting messages:", err);
+    logger.error("Export messages failed", {
+      context: "message.getAllMessages",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };
@@ -436,7 +461,11 @@ export const addReaction = async (req, res) => {
 
     return res.status(200).json(updatedMessage);
   } catch (err) {
-    console.error("Error adding reaction:", err);
+    logger.error("Add reaction failed", {
+      context: "message.addReaction",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };
@@ -485,7 +514,11 @@ export const removeReaction = async (req, res) => {
 
     return res.status(200).json(updatedMessage);
   } catch (err) {
-    console.error("Error removing reaction:", err);
+    logger.error("Remove reaction failed", {
+      context: "message.removeReaction",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };
@@ -535,7 +568,11 @@ export const toggleStarMessage = async (req, res) => {
       starredBy: updatedMessage.starredBy,
     });
   } catch (err) {
-    console.error("Error toggling star:", err);
+    logger.error("Toggle star message failed", {
+      context: "message.toggleStarMessage",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };
@@ -555,7 +592,11 @@ export const getStarredMessages = async (req, res) => {
 
     return res.status(200).json(messages);
   } catch (err) {
-    console.error("Error fetching starred messages:", err);
+    logger.error("Fetch starred messages failed", {
+      context: "message.getStarredMessages",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };
@@ -609,7 +650,11 @@ export const deleteMessageForMe = async (req, res) => {
       deletedForMe: message.deletedForMe 
     });
   } catch (err) {
-    console.error("Error deleting message for me:", err);
+    logger.error("Delete message for me failed", {
+      context: "message.deleteMessageForMe",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };
@@ -742,7 +787,12 @@ export const forwardMessage = async (req, res) => {
           });
         }
       } catch (recipientError) {
-        console.error(`Error forwarding to ${recipient.id}:`, recipientError);
+        logger.error("Forwarding to recipient failed", {
+          context: "message.forwardMessage.recipient",
+          recipientId: recipient.id,
+          error: recipientError.message,
+          stack: recipientError.stack,
+        });
         errors.push({ recipient: recipient.id, error: recipientError.message });
       }
     }
@@ -763,7 +813,11 @@ export const forwardMessage = async (req, res) => {
     });
 
   } catch (err) {
-    console.error("Error forwarding message:", err);
+    logger.error("Forward message failed", {
+      context: "message.forwardMessage",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };
@@ -838,7 +892,11 @@ export const getMedia = async (req, res) => {
     });
 
   } catch (err) {
-    console.error("Error fetching media:", err);
+    logger.error("Fetch media failed", {
+      context: "message.getMedia",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };

--- a/backend/src/controllers/privacy.controller.js
+++ b/backend/src/controllers/privacy.controller.js
@@ -2,6 +2,7 @@ import mongoose from "mongoose";
 import User from "../models/user.model.js";
 import Report from "../models/report.model.js";
 import Message from "../models/message.model.js";
+import logger from "../lib/logger.js";
 
 // Block a user
 export const blockUser = async (req, res) => {
@@ -33,7 +34,11 @@ export const blockUser = async (req, res) => {
 
     return res.status(200).json({ message: "User blocked successfully" });
   } catch (err) {
-    console.error("Error blocking user:", err);
+    logger.error("Block user failed", {
+      context: "privacy.blockUser",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };
@@ -63,7 +68,11 @@ export const unblockUser = async (req, res) => {
 
     return res.status(200).json({ message: "User unblocked successfully" });
   } catch (err) {
-    console.error("Error unblocking user:", err);
+    logger.error("Unblock user failed", {
+      context: "privacy.unblockUser",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };
@@ -83,7 +92,11 @@ export const getBlockedUsers = async (req, res) => {
 
     return res.status(200).json({ blockedUsers: user.blockedUsers });
   } catch (err) {
-    console.error("Error fetching blocked users:", err);
+    logger.error("Fetch blocked users failed", {
+      context: "privacy.getBlockedUsers",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };
@@ -152,7 +165,11 @@ export const reportUser = async (req, res) => {
       reportId: report._id,
     });
   } catch (err) {
-    console.error("Error reporting user:", err);
+    logger.error("Report user failed", {
+      context: "privacy.reportUser",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };
@@ -171,7 +188,11 @@ export const getReports = async (req, res) => {
 
     return res.status(200).json({ reports });
   } catch (err) {
-    console.error("Error fetching reports:", err);
+    logger.error("Fetch reports failed", {
+      context: "privacy.getReports",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };
@@ -187,7 +208,11 @@ export const isUserBlocked = async (req, res) => {
 
     return res.status(200).json({ isBlocked });
   } catch (err) {
-    console.error("Error checking block status:", err);
+    logger.error("Check block status failed", {
+      context: "privacy.isUserBlocked",
+      error: err.message,
+      stack: err.stack,
+    });
     return res.status(500).json({ message: "Internal Server Error" });
   }
 };

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -10,6 +10,7 @@ import groupRoutes from "./routes/group.route.js";
 import privacyRoutes from "./routes/privacy.route.js";
 import { app, server } from "./lib/socket.js";
 import { UPLOAD, SERVER } from "./constants/index.js";
+import logger from "./lib/logger.js";
 
 dotenv.config({ path: ".local.env", quiet: true });
 dotenv.config({ path: ".env", quiet: true });
@@ -63,17 +64,26 @@ app.get("/",(req,res)=>{
 
 server.on("error", (err) => {
   if (err.code === "EADDRINUSE") {
-    console.error(
-      `Port ${PORT} is already in use. Stop the existing backend process first, then restart nodemon.`
-    );
+    logger.error("Server port is already in use", {
+      context: "server.startup",
+      port: PORT,
+      error: err.message,
+    });
     process.exit(1);
   }
 
-  console.error("Server startup error:", err);
+  logger.error("Server startup error", {
+    context: "server.startup",
+    error: err.message,
+    stack: err.stack,
+  });
   process.exit(1);
 });
 
 server.listen(PORT,()=>{
-    console.log(`server is running on port ${PORT}`);
+    logger.info("Server is running", {
+      context: "server.startup",
+      port: PORT,
+    });
     connectDB()
 })

--- a/backend/src/lib/db.js
+++ b/backend/src/lib/db.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import logger from './logger.js';
 
 export const connectDB=async()=>{
     try{
@@ -8,7 +9,10 @@ export const connectDB=async()=>{
        }
 
        const conn = await mongoose.connect(mongoUri)
-       console.log(`MongoDB Connected: ${conn.connection.host}`)
+       logger.info("MongoDB connected", {
+         context: "db.connect",
+         host: conn.connection.host,
+       });
 
        // Cleanup stale index left from older schema versions.
        // It blocks signups with: duplicate key error index userId_1.
@@ -18,10 +22,17 @@ export const connectDB=async()=>{
 
        if (hasDeprecatedUserIdIndex) {
          await userCollection.dropIndex("userId_1");
-         console.log("Dropped deprecated users index: userId_1");
+         logger.info("Dropped deprecated users index", {
+           context: "db.connect",
+           index: "userId_1",
+         });
        }
     }
     catch(err){
-        console.log("mongoDB connection error",err);
+        logger.error("MongoDB connection error", {
+          context: "db.connect",
+          error: err.message,
+          stack: err.stack,
+        });
     }
 }

--- a/backend/src/lib/email.js
+++ b/backend/src/lib/email.js
@@ -1,4 +1,5 @@
 import SibApiV3Sdk from "sib-api-v3-sdk";
+import logger from "./logger.js";
 
 const emailApi = new SibApiV3Sdk.TransactionalEmailsApi();
 
@@ -19,7 +20,11 @@ export const sendEmail = async ({ to, subject, text }) => {
         });
         return response;
     } catch (error) {
-        console.error("Email API Error:", error.message);
+        logger.error("Email API request failed", {
+            context: "email.send",
+            error: error.message,
+            stack: error.stack,
+        });
         throw error;
     }
 };

--- a/backend/src/lib/logger.js
+++ b/backend/src/lib/logger.js
@@ -1,0 +1,21 @@
+import { createLogger, format, transports } from "winston";
+
+const isProduction = process.env.NODE_ENV === "production";
+
+const logger = createLogger({
+  level: process.env.LOG_LEVEL || (isProduction ? "info" : "debug"),
+  format: format.combine(
+    format.timestamp(),
+    format.errors({ stack: true }),
+    format.metadata({ fillExcept: ["message", "level", "timestamp"] }),
+    format.json()
+  ),
+  transports: [
+    new transports.Console({
+      handleExceptions: true,
+    }),
+  ],
+  exitOnError: false,
+});
+
+export default logger;

--- a/backend/src/lib/socket.js
+++ b/backend/src/lib/socket.js
@@ -6,6 +6,7 @@ import dotenv from "dotenv";
 import User from "../models/user.model.js";
 import Conversation from "../models/conversation.model.js";
 import { createRoomKey } from "./conversation.js";
+import logger from "./logger.js";
 
 dotenv.config({ path: ".local.env", quiet: true });
 dotenv.config({ path: ".env", quiet: true });
@@ -20,7 +21,10 @@ const allowedOrigins = [process.env.FRONTEND_URL].filter(Boolean);
 
 const logSocketWarning = (message, error) => {
   if (process.env.NODE_ENV !== "production") {
-    console.warn(message, error?.message || error);
+    logger.warn(message, {
+      context: "socket",
+      error: error?.message || error,
+    });
   }
 };
 

--- a/backend/src/middleware/auth.middleware.js
+++ b/backend/src/middleware/auth.middleware.js
@@ -1,5 +1,6 @@
 import jwt from "jsonwebtoken"
 import User from "../models/user.model.js"
+import logger from "../lib/logger.js"
 
 export const protectRoute=async (req,res,next)=>{
     try{
@@ -25,7 +26,11 @@ export const protectRoute=async (req,res,next)=>{
         next();
     }
     catch(err){
-        console.log("error in protect route middleware",err);
+        logger.error("Protect route middleware failed", {
+            context: "middleware.protectRoute",
+            error: err.message,
+            stack: err.stack,
+        });
         res.status(500).json({message:"Internal server error"});
     }
 

--- a/backend/src/seeds/user.seed.js
+++ b/backend/src/seeds/user.seed.js
@@ -1,6 +1,7 @@
 import { config } from "dotenv";
 import { connectDB } from "../lib/db.js";
 import User from "../models/user.model.js";
+import logger from "../lib/logger.js";
 
 config();
 
@@ -105,9 +106,15 @@ const seedDatabase = async () => {
     await connectDB();
 
     await User.insertMany(seedUsers);
-    console.log("Database seeded successfully");
+    logger.info("Database seeded successfully", {
+      context: "seed.users",
+    });
   } catch (error) {
-    console.error("Error seeding database:", error);
+    logger.error("Error seeding database", {
+      context: "seed.users",
+      error: error.message,
+      stack: error.stack,
+    });
   }
 };
 


### PR DESCRIPTION


What I changed

- Added Winston dependency in package.json and updated package-lock.json.
- Created shared logger at logger.js with JSON logs, timestamps, stack support, and environment-based log level.
- Replaced console logging with logger calls (info/warn/error + context metadata) in:
  - auth.controller.js
  - group.controller.js
  - message.controller.js
  - privacy.controller.js
  - socket.js
  - db.js
  - email.js
  - auth.middleware.js
  - index.js
  - user.seed.js

Verification performed

- Ran install: npm install winston in backend.
- Searched for remaining console usage in backend source: no console.* matches found in backend/src.
- Checked diagnostics on backend/src: no errors found.



closes #73